### PR TITLE
Adding section for ease on C# Walkthrough

### DIFF
--- a/docs/csharp/cs-dev-kit-faq.md
+++ b/docs/csharp/cs-dev-kit-faq.md
@@ -4,7 +4,7 @@ Area: csharp
 TOCTitle: FAQ
 ContentId: edd2c270-152c-419d-b5d9-06f2f95979cd
 PageTitle: C# Dev Kit extension FAQ
-DateApproved: 7/11/2023
+DateApproved: 9/21/2023
 MetaDescription: C# Dev Kit extension Frequently Asked Questions (FAQ)
 ---
 
@@ -33,7 +33,7 @@ Today the extensions included in the C# Dev Kit family are:
 
 Use of these extensions are governed under the [EULA for the C# Dev Kit family of extensions](https://aka.ms/vs/csdevkit/license).
 
-These extensions also have dependencies which carry their own licensing – for example, the C# Dev Kit extension depends on the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
+These extensions also have dependencies that carry their own licensing – for example, the C# Dev Kit extension depends on the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 
 ### Who can use C# Dev Kit?
 
@@ -59,145 +59,176 @@ This project has adopted the code of conduct defined by the [Contributor Covenan
 
 ## .NET SDK
 
-### Install Script Timeouts. What should I do?
+### Install script timed out
 
-Please note that, depending on your network speed, installing the .NET Core runtime might take some time. By default, the installation terminates unsuccessfully if it takes longer than 4.5 minutes to finish. If you believe this is too little (or too much) time to allow for the download, you can change the timeout value by setting dotnetAcquisitionExtension.installTimeoutValue to a custom value.
+Note that, depending on your network speed, installing the .NET Core runtime might take some time. By default, the installation terminates unsuccessfully if it takes longer than 4.5 minutes to finish. If you believe this is too little (or too much) time to allow for the download, you can change the timeout value by setting `dotnetAcquisitionExtension.installTimeoutValue` to a custom value.
 
-[Learn more about configuring Visual Studio Code settings](https://code.visualstudio.com/docs/getstarted/settings) and see below for an example of a custom timeout in a settings.json file. In this example the custom timeout value is 180 seconds, or 3 minutes.
+[Learn more about configuring VS Code settings](/docs/getstarted/settings.md) and see below for an example of a custom timeout in a `settings.json` file. In this example, the custom timeout value is 180 seconds, or 3 minutes:
 
-![Custom Timeout Value](images/faq/dotnet-sdk-timeout.png)
+```json
+{
+    "dotnetAcquisitionExtension.installTimeoutValue": 180
+}
+```
 
 ### How do I manually install .NET?
 
-If .NET installation is failing or you want to reuse an existing installation of .NET, you can use the dotnetAcquisitionExtension.existingDotnetPath setting. .NET can be manually installed from the [.NET website](https://dotnet.microsoft.com/download). To direct this extension to that installation, update your settings with the extension ID and the path as illustrated below.
+If .NET installation is failing or you want to reuse an existing installation of .NET, you can use the `dotnetAcquisitionExtension.existingDotnetPath` setting. .NET can be manually installed from the [.NET website](https://dotnet.microsoft.com/download). To direct the extension to that installation, update your settings with the extension ID and the path as illustrated below:
 
-![Setting the .NET Acquisition Extension Path ](images/faq/dotnet-sdk-path.png)
+#### Windows
+
+```json
+{
+    "dotnetAcquisitionExtension.existingDotnetPath": [
+        { "extensionId": "msazuretools.azurerm-vscode-tools", "path": "C\\Program Files\\dotnet\\dotnet.exe" }
+    ]
+}
+```
+
+#### macOS
+
+```json
+{
+    "dotnetAcquisitionExtension.existingDotnetPath": [
+        { "extensionId": "msazuretools.azurerm-vscode-tools", "path": "/usr/local/share/dotnet/dotnet" }
+    ]
+}
+```
 
 ## Project System
 
-### The Solution Explorer tells me my project is not supported in C# Dev Kit. What should I do?
+### The Solution Explorer reports that my project is not supported in C# Dev Kit
 
-This is usually because the project targets .NET Framework rather than .NET Core/.NET. C# Dev Kit does not support .NET Framework projects.
+This is usually because the project targets .NET Framework rather than .NET Core/.NET. At this time, C# Dev Kit does not support .NET Framework projects.
 
 ![Project Not Supported in Solution Explorer](images/faq/solution-explorer-not-supported-framework.png)
 
-You can either [update your project](https://learn.microsoft.com/en-us/dotnet/core/porting/) to an SDK-style project to use all available C# Dev Kit features. Or you can use the new Prefer CSharp Extension workspace setting located in the Settings UI.
-This setting delegates solution and project load to the C# extension. The C# extension will then perform its typical tasks, such as loading IntelliSense, while C# Dev Kit will halt and not attempt to load the solution or any associated projects.
+You will need to [update your project](https://learn.microsoft.com/dotnet/core/porting/) to an SDK-style project to use all available C# Dev Kit features.
 
-### I clicked on the “Create .NET Project” button or used the .NET: Create .NET Project command option, and nothing happened
+### I clicked on the "Create .NET Project" button and nothing happened
 
-This usually occurs when there is an extension version mismatch. C# Dev Kit requires version 2.0 or greater of the C# extension. If you are on v1 of the C# extension, C# Dev Kit, and the C# Dev Kit related commands will not work properly. To fix this, upgrade the C# extension to the latest version.
+This usually occurs when there is an extension version mismatch. C# Dev Kit requires version 2.0 or greater of the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp). If you are on v1 of the C# extension, C# Dev Kit, and the C# Dev Kit related commands will not work properly. To fix this, upgrade the C# extension to the latest version.
 
-### The Project System says it ran into a problem. What should I do?
+### The Project System reports that it ran into a problem
 
-When an internal Project System error occurs, you’ll generally see a notification like this pop up in a corner of VS Code:
+When an internal Project System error occurs, you'll generally see a notification like this pop up in a corner of VS Code:
 
 ![Failed to Restore Solution](images/faq/failed-to-restore-solution.png)
 
-Click the “Open log” button to open a view showing a stack trace of where the problem occurred. Select and copy all the text in the log. Report the issue through VS Code and make sure to include the copied text from the log.
+Select the **Open log** button to open a view showing a stack trace of where the problem occurred. Select and copy all the text in the log. Report the issue through VS Code and make sure to include the copied text from the log.
 
-### When I open my solution, I get a toast message, “Failed to restore solution”
+### When I open my solution, I get the notification "Failed to restore solution"
 
-Click on Show error. This will open the Output pane for NuGet. Read through the error to determine why the package restore was unable to complete. If you are unable to resolve the problem, report the issue through VS Code.
+Select **Show error**. This opens the Output panel for NuGet. Read through the error to determine why the package restore was unable to complete. If you are unable to resolve the problem, report the issue through VS Code.
 
-### The Solution Explorer tells me that “A compatible .NET SDK was not found”. What should I do?
+### The Solution Explorer displays "A compatible .NET SDK was not found"
 
-The most likely cause of this error is a global.json file that specifies a different SDK than what is installed on the system.
+The most likely cause of this error is a `global.json` file that specifies a different SDK than what is installed on the system.
 
 ![A compatible .NET SDK was not found](images/faq/compatible-dotnet-sdk-not-found.png)
 
-Open the Output window and switch to the “Projects” pane to look for more information.
+Open the Output window (`kb(workbench.action.output.toggleOutput)`) and switch to the **Projects** pane to look for more information.
 
-To fix the issue, either update the global.json to specify an installed SDK or install the specified SDK from https://aka.ms/dotnet/download.
+To fix the issue, either update the `global.json` to specify an installed SDK or install the specified SDK from the [Download .NET](https://aka.ms/dotnet/download) page.
 
-Next, close and re-open the workspace.
+Next, close and reopen the workspace.
 
-It is also possible that the SDK is not installed in a location known to C# Dev Kit. This can happen, for example, if the SDK was installed by a package manager rather than through the MS-provided installers. To fix this, uninstall the SDK via the package manager, and then install it via https://aka.ms/dotnet/download.
+It is also possible that the SDK is not installed in a location known to C# Dev Kit. This can happen, for example, if the SDK was installed by a package manager rather than through the Microsoft-provided installers. To fix this, uninstall the SDK via the package manager, and then install it via [Download .NET](https://aka.ms/dotnet/download).
 
 ## Test Explorer
 
-### Why don’t my tests appear in the Test Explorer pane?
+### Why don't my tests appear in the Test Explorer panel?
 
-Make sure your solution includes a test project. Only test projects that are part of the opened solution will be included. To see if the test project is part of the solution, open the Solution Explorer panel on the file pane and see if the project appears in the tree. Right click on the solution node to add existing test projects, or to create a new test project in the solution.
+Make sure your solution includes a test project. Only test projects that are part of the opened solution will be included. To see if the test project is part of the solution, open the Solution Explorer view in the File Explorer and see if the project appears in the tree. Right-click on the solution node to add existing test projects, or to create a new test project in the solution.
 
-C# Dev Kit also requires that it has built your project successfully before tests will appear in the Test Explorer pane. Also, if a “Clean” is done on your project/solution, the test dlls will be removed from the test explorer pane.
+C# Dev Kit also requires that it has built your project successfully before tests appear in the Test Explorer panel. Also, if a **Clean** is done on your project/solution, the test dlls are removed from the Test Explorer panel.
 
-Once you have validated that your test project is part of the solution, “Build” your solution by right clicking on the solution in the Solution Explorer and select “Build” or Ctrl-Shift-B. Once the build has been completed, your tests will appear in the Test Explorer Pane.
+Once you have validated that your test project is part of the solution, build your solution by right-clicking on the solution in the Solution Explorer and select **Build** or use `kb(workbench.action.tasks.build)`. Once the build has been completed, your tests will appear in the Test Explorer panel.
 
-### My tests appear in the test window, but I cannot debug them
+### My tests appear in the Test Explorer panel, but I cannot debug them
 
-Make sure that your tests are targeting NET Core. C# Dev Kit does not support .NET Framework projects, although .NET Framework projects may load and appear to work. The debugger in VSCode does not support .NET Framework.
+Make sure that your tests are targeting NET Core. C# Dev Kit does not support .NET Framework projects, although .NET Framework projects may load and appear to work. The debugger in VS Code does not support .NET Framework.
 
-### I just added new tests to my test project, and they are not appearing in the Test Explorer pane?
+### I just added new tests to my test project, and they are not appearing in the Test Explorer panel?
 
-C# Dev Kit requires that it has built your project successfully before tests will appear in the Test Explorer pane.
+C# Dev Kit requires that it has built your project successfully before tests will appear in the Test Explorer panel.
 
-“Build” your solution by right clicking on the solution in the Solution Explorer and select “Build” or Ctrl-Shift-B. Once the build has been completed, your tests will appear in the Test Explorer Pane.
+Build your solution by right-clicking on the solution in the Solution Explorer and select **Build** or `kb(workbench.action.tasks.build)`. Once the build has been completed, your tests will appear in the Test Explorer panel.
 
 ## Debugger
 
-### When I F5, nothing happens. What should I do?
+### When I F5, nothing happens
 
-Make sure you have a C# project open or that the active document is a .cs or .razor file. If the debugger still fails to load, make sure that both the C# Dev Kit and the C# Extension have been activated.
+Make sure you have a C# project open or that the active document is a `.cs` or `.razor` file. If the debugger still fails to load, make sure that both the C# Dev Kit and the C# extensions have been activated.
 
-### When I F5, it asks me to “Select a Debugger”. How do I know which one to pick?
+### When I F5, it asks me to "Select a Debugger". How do I know which one to pick?
 
-If you're trying to debug .NET Console Applications, Blazor Server Apps, Blazor WebAssembly, or Web Applications, make sure to select the 'C#' option. The other options may be part of other extensions such as 'Node' for JavaScript debugging or 'Python' for Python debugging, and are not part of C# Dev Kit.
+If you're trying to debug .NET Console Applications, Blazor Server Apps, Blazor WebAssembly, or Web Applications, make sure to select the **C#** option. The other options may be part of other extensions such as **Node** for JavaScript debugging or **Python** for Python debugging, and are not part of C# Dev Kit.
 
 ### Why is debugging not working?
 
-If you're trying to debug a library or a test project, it's likely that you'll need to take some extra steps to ensure that your code is properly debugged. To debug a library, you can create a console or web application that interacts with the library. For a test project, you can use the test explorer to debug your code effectively.
+If you're trying to debug a library or a test project, it's likely that you'll need to take some extra steps to ensure that your code is properly debugged. To debug a library, you can create a console or web application that interacts with the library. For a test project, you can use the Test Explorer to debug your code effectively.
 
-### While debugging my breakpoints aren't binding
+### While debugging, my breakpoints aren't binding
 
-The process you’re debugging is not built in Debug, make sure to build as debugging before debugging the process.
+The process you're debugging is not built in Debug, make sure to build as debugging before debugging the process.
 
 ## C# Editor
 
 ### How do I get IntelliSense to work correctly?
 
-Make sure that you have a project or solution open. If you have multiple solutions, we will automatically open one or prompt you to open one. Next, search for "Trace" in the Settings search bar, and set the Dotnet > Server to Trace from the drop-down. This will provide more output information to help the developer team diagnose the issue.
+Make sure that you have a project or solution open. If you have multiple solutions, the extension will automatically open one or prompt you to open one. Next, search for "Trace" in the Settings search bar, and set the **Dotnet** > **Server:** to **Trace** from the drop-down. This option provides more output information to help the developer team diagnose the issue.
 
 ![Set Dotnet Server to Trace](images/faq/dotnet-server-trace.png)
 
-Once you've made this change, reload the window by typing Ctrl + Shift + P to open the Command Palette, then typing "Reload Window" and pressing Enter. After reloading the window, check the project log in the Output Window by typing Ctrl+Shift+U and selecting "Projects" from the drop-down. This will show any errors related to your project not being fully loaded. Copy all the text in the Output Window and report the issue through VS Code, making sure to include the copied text.
+Once you've made this change, reload the window by opening the Command Palette (`kb(workbench.action.showCommands)`), then typing "Reload Window" and pressing `kbstyle(Enter)`. After reloading the window, check the project log in the Output panel (`kb(workbench.action.output.toggleOutput)`) and selecting **Projects** from the drop-down. This will show any errors related to your project not being fully loaded. Copy all the text in the Output panel and report the issue through VS Code, making sure to include the copied text.
 
-### C# extension fails to launch the server. What should I do?
+### C# extension fails to launch the server
 
-As a workaround, you can point the .NET runtime acquisition extension to an existing .NET 7 install:
+As a workaround, you can point the .NET runtime acquisition extension to an existing .NET 7 install with the `dotnetAcquisitionExtension.existingDotnetPath` setting:
 
-![Setting .NET Runtime to an Existing .NET 7 Install](images/faq/dotnet-runtime-path.png)
+```json
+{
+    "dotnetAcquisitionExtension.existingDotnetPath": [
+        {
+            "extensionId": "msazuretools.azurerm-vscode-tools",
+            "path": "C\\Program Files\\dotnet\\dotnet.exe"
+        }
+    ]
+}
 
-### I have too many diagnostics or I don’t have enough diagnostics
+```
 
-The C# Extension allows you to configure various background code analysis settings. To access the Settings, go to File > Preferences > Settings or use the shortcut (Ctrl+,). In the search bar, type "analysis" to narrow down the settings related to code analysis. Under "Run background code analysis for:", you can choose the analysis scope from a drop-down menu. The default setting is to analyze open files, but you can customize it to full solution, none, or open documents.
+### I have too many diagnostics or I don't have enough diagnostics
+
+The [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) allows you to configure various background code analysis settings. To access the settings, go to **File** > **Preferences** > **Settings** or use the keyboard shortcut (`kb(workbench.action.openSettings)`). In the search bar, type "analysis" to narrow down the settings related to code analysis. Under **Run background code analysis for:**, you can choose the analysis scope from a drop-down menu. The default setting is to analyze open files, but you can customize it to full solution, none, or open documents.
 
 ![Configure Background Code Analysis](images/faq/background-code-analysis.png)
 
 You can also use an EditorConfig file to configure diagnostics and code analysis. To learn more about EditorConfig, check out the [documentation](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/code-style-rule-options).
 
-If you're not seeing enough diagnostics or none at all, it's possible that your project isn't fully loaded. To check if this is the case, refer to the troubleshooting guide for "IntelliSense is not working". It provides instructions on how to verify if your project is fully loaded.
+If you're not seeing enough diagnostics or none at all, it's possible that your project isn't fully loaded. To check if this is the case, refer to the section [How do I get IntelliSense to work correctly?](#how-do-i-get-intellisense-to-work-correctly) It provides instructions on how to verify if your project is fully loaded.
 
 ## Razor Editor
 
-### Most or all Blazor components show up with warnings. Why?
+### Most or all Blazor components show up with warnings
 
-Before Blazor components can be discovered, C# Dev Kit needs to load your project successfully. Additionally, the Razor language server requires a "project.razor.vscode.json" file to be generated in order to understand the state of your projects. If this file isn't generated, or is generated without any components, the Razor experience may be affected.
+Before Blazor components can be discovered, C# Dev Kit needs to load your project successfully. Additionally, the Razor language server requires a `project.razor.vscode.json` file to be generated in order to understand the state of your projects. If this file isn't generated, or is generated without any components, the Razor experience may be affected.
 
-To improve performance, we sometimes defer generating or loading this file until you open your first .razor or .cshtml file. To ensure that there are no errors in the Solution Explorer for the project you're trying to use, please check it carefully.
+To improve performance, the extension sometimes defers generating or loading this file until you open your first `.razor` or `.cshtml` file. To ensure that there are no errors in the Solution Explorer for the project you're trying to use, check it carefully.
 
-If your project has loaded correctly, verify that a "project.razor.vscode.json" file exists in the "obj\Debug\<tfm>" folder on your file system. In that file, make sure that there isn't an empty array of "TagHelpers".
+If your project has loaded correctly, verify that a `project.razor.vscode.json` file exists in the `obj\Debug\<tfm>` folder on your file system. In that file, make sure that there isn't an empty array of `TagHelpers`.
 
-To force the file to re-generate, close any open .razor or .cshtml files, reload the VS Code window, and once the project has loaded correctly, open any .razor or .cshtml file to trigger the regeneration process.
+To force the file to regenerate, close any open `.razor` or `.cshtml` files, reload the VS Code window, and once the project has loaded correctly, open any `.razor` or `.cshtml` file to trigger the regeneration process.
 
-### Target framework errors are mentioned in Razor files. Why?
+### Target framework errors are mentioned in Razor files
 
-The Razor language server generally does not have a concept of a “solution”, but instead loads projects based on the presence of a “project.razor.vscode.json” file in the projects “obj\Debug\<tfm>” folder. Sometimes, old files from target frameworks that are no longer in use can cause confusion, making the Razor server think a project is multi-targeted or that some components are still referenced when they're not.
+The Razor language server generally does not have a concept of a "solution", but instead loads projects based on the presence of a `project.razor.vscode.json` file in the projects `obj\Debug\<tfm>` folder. Sometimes, old files from target frameworks that are no longer in use can cause confusion, making the Razor server think a project is multi-targeted or that some components are still referenced when they're not.
 
-To resolve this issue, clear out old folders from within the "obj" folder or clear all of them. Then, reload the VS Code window and open a .razor file. This should ensure that new json files are generated, and the old ones are removed.
+To resolve this issue, clear out old folders from within the `obj` folder or clear all of them. Then, reload the VS Code window and open a `.razor` file. This should ensure that new JSON files are generated, and the old ones are removed.
 
 ## IntelliCode
 
-### I am not getting Whole Line Completions. Why not?
+### I am not getting whole line completions
 
-Whole line completions are disabled when Copilot is enabled to allow you take advantage of the more advanced AI completion capabilities. You can verify that Copilot is enabled by verifying the Copilot logo is present in the lower right corner of VS Code.
+Whole line completions are disabled when the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) extension is enabled to allow you to take advantage of the more advanced [AI completion](/docs/editor/artificial-intelligence.md) capabilities. You can verify that Copilot is enabled by checking if the Copilot logo is present in the lower right corner of VS Code.

--- a/docs/csharp/images/faq/dotnet-runtime-path.png
+++ b/docs/csharp/images/faq/dotnet-runtime-path.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91048d20723012ce284b686fed7ab9764d1175ac078d39e38befde387d7d03bd
-size 39197

--- a/docs/csharp/images/faq/dotnet-sdk-path.png
+++ b/docs/csharp/images/faq/dotnet-sdk-path.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59693e16c00914d350a1a77e58074bb4019fe9aeb71a43c8e2cedbe5055ff0dd
-size 64662

--- a/docs/csharp/images/faq/dotnet-sdk-timeout.png
+++ b/docs/csharp/images/faq/dotnet-sdk-timeout.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abe42266ef0a2e30238d8e6ad0cbf304efa0112e2c05ba8f9a710d90c8b51a6e
-size 12652


### PR DESCRIPTION
We've got a lot of complaints that we don't talk enough about SE in our docs. Adding a section to Getting Started that introduces the Solution Explorer.